### PR TITLE
fix(lex-knowledge): gap fixes — metadata→context, embed fallback, retire tag, error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.11] - 2026-05-03
+
+### Fixed
+- Knowledge query synthesis now passes prompts directly into native `Legion::LLM.chat` dispatch instead of routing through the legacy nil-input `llm_chat` helper path.
+
 ## [0.6.10] - 2026-04-28
 
 ### Fixed

--- a/lib/legion/extensions/knowledge/actors/maintenance_runner.rb
+++ b/lib/legion/extensions/knowledge/actors/maintenance_runner.rb
@@ -22,16 +22,20 @@ module Legion
           end
 
           def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
-            return false unless corpus_path && !corpus_path.empty?
+            return true if corpus_path && !corpus_path.empty?
 
-            true
+            Runners::Monitor.resolve_monitors.any?
           rescue StandardError => e
             log.warn(e.message)
             false
           end
 
           def args
-            { path: corpus_path }
+            path = corpus_path
+            return { path: path } if path && !path.empty?
+
+            monitors = Runners::Monitor.resolve_monitors
+            monitors.any? ? { path: monitors.first[:path] } : { path: nil }
           end
 
           private

--- a/lib/legion/extensions/knowledge/runners/ingest.rb
+++ b/lib/legion/extensions/knowledge/runners/ingest.rb
@@ -186,7 +186,7 @@ module Legion
           private_class_method :build_exists_map
 
           def llm_embed_available?
-            defined?(Legion::LLM) && Legion::LLM.respond_to?(:embed_batch)
+            defined?(Legion::LLM) && (Legion::LLM.respond_to?(:embed_batch) || Legion::LLM.respond_to?(:embed))
           end
           private_class_method :llm_embed_available?
 
@@ -196,9 +196,19 @@ module Legion
           private_class_method :paired_without_embed
 
           def build_embed_map(needs_embed)
-            results = Legion::LLM.embed_batch(needs_embed.map { |c| c[:content] }) # rubocop:disable Legion/HelperMigration/DirectLlm
-            results.each_with_object({}) do |r, h|
-              h[needs_embed[r[:index]][:content_hash]] = r[:vector] unless r[:error]
+            if Legion::LLM.respond_to?(:embed_batch)
+              results = Legion::LLM.embed_batch(needs_embed.map { |c| c[:content] }) # rubocop:disable Legion/HelperMigration/DirectLlm
+              results.each_with_object({}) do |r, h|
+                h[needs_embed[r[:index]][:content_hash]] = r[:vector] unless r[:error]
+              end
+            else
+              needs_embed.each_with_object({}) do |chunk, h|
+                result = Legion::LLM.embed(chunk[:content]) # rubocop:disable Legion/HelperMigration/DirectLlm
+                vector = result.is_a?(Hash) ? result[:vector] : result
+                h[chunk[:content_hash]] = vector if vector.is_a?(Array) && vector.any?
+              rescue StandardError => e
+                log.warn(e.message)
+              end
             end
           rescue StandardError => e
             log.warn(e.message)
@@ -253,7 +263,7 @@ module Legion
               content_type: 'document_chunk',
               content_hash: chunk[:content_hash],
               tags:         [chunk[:source_file], chunk[:heading], 'document_chunk'].compact.uniq,
-              metadata:     {
+              context:      {
                 source_file:  chunk[:source_file],
                 heading:      chunk[:heading],
                 section_path: chunk[:section_path],
@@ -272,10 +282,10 @@ module Legion
             return unless Legion::Apollo.respond_to?(:ingest) && Legion::Apollo.started?
 
             Legion::Apollo.ingest( # rubocop:disable Legion/HelperMigration/DirectKnowledge
-              content:      file_path,
-              content_type: 'document_retired',
+              content:      "Retired document: #{file_path}",
+              content_type: 'observation',
               tags:         [file_path, 'retired', 'document_chunk'].uniq,
-              metadata:     { source_file: file_path, retired: true }
+              context:      { source_file: file_path, retired: true }
             )
           rescue StandardError => e
             log.warn(e.message)

--- a/lib/legion/extensions/knowledge/runners/maintenance.rb
+++ b/lib/legion/extensions/knowledge/runners/maintenance.rb
@@ -279,7 +279,7 @@ module Legion
           def query_count
             return 0 unless defined?(Legion::Data::Model::ApolloAccessLog)
 
-            Legion::Data::Model::ApolloAccessLog.where(action: 'knowledge_query').count
+            Legion::Data::Model::ApolloAccessLog.where(action: 'query').count
           rescue StandardError => _e
             0
           end

--- a/lib/legion/extensions/knowledge/runners/query.rb
+++ b/lib/legion/extensions/knowledge/runners/query.rb
@@ -9,6 +9,11 @@ module Legion
         module Query # rubocop:disable Legion/Extension/RunnerIncludeHelpers
           module_function
 
+          def log
+            Legion::Logging
+          end
+          private_class_method :log
+
           def query(question:, top_k: nil, synthesize: true)
             started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
             resolved_k = top_k || settings_top_k || 5
@@ -75,7 +80,8 @@ module Legion
               tags:  ['document_chunk']
             )
             result.is_a?(Hash) && result[:success] ? Array(result[:entries]) : []
-          rescue StandardError => _e
+          rescue StandardError => e
+            log.warn("[knowledge][retrieve_chunks] retrieval failed: #{e.class}: #{e.message}")
             []
           end
           private_class_method :retrieve_chunks
@@ -97,7 +103,8 @@ module Legion
             )
             result.is_a?(Hash) ? result[:content] : result.content
           rescue StandardError => e
-            "Error generating answer: #{e.message}"
+            log.warn("[knowledge][synthesize_answer] LLM synthesis failed: #{e.class}: #{e.message}")
+            nil
           end
           private_class_method :synthesize_answer
 

--- a/lib/legion/extensions/knowledge/runners/query.rb
+++ b/lib/legion/extensions/knowledge/runners/query.rb
@@ -91,8 +91,11 @@ module Legion
                          "Context:\n#{context_text}\n\nQuestion: #{question}\n\nAnswer:"
                      end
 
-            result = llm_chat(message: prompt, caller: { extension: 'lex-knowledge' })
-            result.is_a?(Hash) ? result[:content] : result
+            result = Legion::LLM.chat( # rubocop:disable Legion/HelperMigration/DirectLlm
+              message: prompt,
+              caller:  { extension: 'lex-knowledge' }
+            )
+            result.is_a?(Hash) ? result[:content] : result.content
           rescue StandardError => e
             "Error generating answer: #{e.message}"
           end

--- a/lib/legion/extensions/knowledge/version.rb
+++ b/lib/legion/extensions/knowledge/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Knowledge
-      VERSION = '0.6.10'
+      VERSION = '0.6.11'
     end
   end
 end


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Seven correctness fixes across `runners/ingest.rb`, `runners/query.rb`, `runners/maintenance.rb`, and `actors/maintenance_runner.rb`.

- **Fix 1 — `metadata:` → `context:` in `ingest_to_apollo`** (CRITICAL): chunk provenance (`source_file`, `heading`, `section_path`, `chunk_index`, `token_count`) was silently dropped by Ruby's double-splat because `handle_ingest` expects `context:`. Every lex-knowledge chunk stored `'{}'` in `apollo_entries.source_context`, breaking all maintenance queries that use `source_context->>'source_file'`.

- **Fix 2 — `llm_embed_available?` now accepts single-embed providers**: previously only checked for `Legion::LLM.embed_batch`; any LLM that only exposes `Legion::LLM.embed` caused all chunks to be stored without embeddings. `build_embed_map` now falls back to per-chunk `embed` calls when `embed_batch` is unavailable.

- **Fix 3 — `retire_file` uses valid content type and `context:` key**: changed `content_type: 'document_retired'` (unknown to lex-apollo, silently stored as `:observation` with no signal) to `content_type: 'observation'` with `tags: [..., 'retired', ...]` for an explicit retirement signal. Also switched `metadata:` → `context:` to match `handle_ingest` signature.

- **Fix 4 — `retrieve_chunks` logs errors instead of swallowing them**: the anonymous `rescue => _e; []` pattern silently hid DB/connection errors, causing `synthesize_answer` to generate hallucinated answers with no context. Now logs at warn level.

- **Fix 5 — `synthesize_answer` returns `nil` on LLM error**: previously returned the error message string (e.g. `"Error generating answer: connection refused"`) as the `answer:` field, which callers presented to users as a real answer. Now returns `nil` and logs at warn level.

- **Fix 6 — `MaintenanceRunner#enabled?` works for monitors-only installs**: `enabled?` previously returned false when `corpus_path` was nil, so the maintenance actor was never scheduled for installs that use `monitors:` config. Now returns true when `Runners::Monitor.resolve_monitors.any?`. `args` falls back to `monitors.first[:path]` in that case.

- **Fix 7 — `query_count` uses correct action string**: `ApolloAccessLog` records use `action: 'query'` (set by lex-apollo), not `'knowledge_query'`. The old value always returned 0, making `quality_report` totals useless.

## Test plan

- [ ] Ingest a corpus file and verify `source_context` in `apollo_entries` contains `source_file`, `heading`, `section_path`, `chunk_index`, `token_count`
- [ ] Configure an LLM provider that only exposes `embed` (not `embed_batch`) and confirm chunks are stored with embeddings
- [ ] Remove a file from a corpus and confirm the retirement entry has `content_type: 'observation'` and tags include `'retired'`
- [ ] Simulate a retrieval failure (take Apollo offline) and confirm a warn-level log line is emitted, not a hallucinated answer
- [ ] Simulate an LLM failure during synthesis and confirm `answer:` is `nil` in the response, not an error string
- [ ] Configure a node with `monitors:` only (no `corpus_path`) and confirm `MaintenanceRunner` is enabled and scheduled
- [ ] Confirm `quality_report` `total_queries` returns a non-zero value after running queries
EOF
)