### PR TITLE
Add source_agent/source_channel to Apollo ingest for provenance

### DIFF
--- a/lib/legion/extensions/knowledge/runners/ingest.rb
+++ b/lib/legion/extensions/knowledge/runners/ingest.rb
@@ -320,12 +320,14 @@ module Legion
               token_count:  chunk[:token_count]
             }
             payload = {
-              content:      chunk[:content],
-              content_type: 'document_chunk',
-              content_hash: chunk[:content_hash],
-              tags:         [chunk[:source_file], chunk[:heading], 'document_chunk'].compact.uniq,
-              context:      context,
-              metadata:     context
+              content:        chunk[:content],
+              content_type:   'document_chunk',
+              content_hash:   chunk[:content_hash],
+              tags:           [chunk[:source_file], chunk[:heading], 'document_chunk'].compact.uniq,
+              source_agent:   'lex-knowledge',
+              source_channel: 'corpus_ingest',
+              context:        context,
+              metadata:       context
             }
             payload[:embedding] = embedding if embedding
 

--- a/lib/legion/extensions/knowledge/version.rb
+++ b/lib/legion/extensions/knowledge/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Knowledge
-      VERSION = '0.6.15'
+      VERSION = '0.6.16'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add `source_agent: 'lex-knowledge'` and `source_channel: 'corpus_ingest'` to `ingest_to_apollo` calls
- Identity columns now enforced at the lex-apollo layer via `Legion::Identity::Process` — no caller changes needed

## Context
Part of cross-repo identity scoping effort. Identity enforcement happens in lex-apollo's `handle_ingest`; lex-knowledge just needs proper source attribution.

Related: LegionIO/lex-apollo PR #24, LegionIO/legion-apollo PR #35, LegionIO/legion-llm PR #127.

## Test plan
- [x] 218 specs passing, 0 failures
- [x] 0 rubocop offenses